### PR TITLE
Provide easy output and error file access for jobs

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -30,5 +30,13 @@ Rake::TestTask.new(:test) do |t|
   t.verbose = false
 end
 
+task :console do
+  require 'irb'
+  require 'irb/completion'
+  require 'osc/machete'
+  require 'osc_machete_rails'
+  ARGV.clear
+  IRB.start
+end
 
 task default: :test

--- a/lib/osc_machete_rails/statusable.rb
+++ b/lib/osc_machete_rails/statusable.rb
@@ -76,6 +76,44 @@ module OscMacheteRails
       valid
     end
 
+    # return string "3950166" whether the is "3950166" or "3960166.oak-batch.osc.edu"
+    def pbsid_number
+      self.pbsid =~ /(\d+)(\..*)?/
+      $1
+    end
+
+    # return first path found for the given filename/path or glob pattern relative
+    # to the job's directory
+    def job_file_path(file)
+      Pathname.glob("#{self.job_path}/#{file}").first
+    end
+
+    def output_file_path
+      self.job_file_path "*.o#{self.pbsid_number}"
+    end
+
+    def error_file_path
+      self.job_file_path "*.e#{self.pbsid_number}"
+    end
+
+    # path relative to dataroot
+    def output_file_relative_path
+      self.output_file_path.relative_path_from(AwesimRails.dataroot) if self.output_file_path
+    end
+
+    # path relative to dataroot
+    def error_file_relative_path
+      self.error_file_path.relative_path_from(AwesimRails.dataroot) if self.error_file_path
+    end
+
+    def output_file_contents
+      self.output_file_path ? self.output_file_path.read : ""
+    end
+
+    def error_file_contents
+      self.error_file_path ? self.error_file_path.read : ""
+    end
+
     #FIXME: should have a unit test for this!
     # job.update_status! will update and save object
     # if submitted? and ! completed? and status changed from previous state


### PR DESCRIPTION
Fixes https://github.com/AweSim-OSC/osc-machete/issues/66

This was moved from Dyna app to OscMacheteRails::Statusable. 

I've pulled the corresponding code out of Dyna and everything is still working as expected.

Models using these features will need to update to include OscMacheteRails::Statusable, but that's expected.
