### PR TITLE
Uses a single JSON column to store OSC::Machete::Job state

### DIFF
--- a/lib/generators/osc_machete_rails/job_model/job_model_generator.rb
+++ b/lib/generators/osc_machete_rails/job_model/job_model_generator.rb
@@ -3,9 +3,7 @@ class OscMacheteRails::JobModelGenerator < Rails::Generators::NamedBase
 
   def initialize(args, *options)
     args |= %w(status:string)
-    args |= %w(pbsid:string)
-    args |= %w(job_path:string)
-    args |= %w(script_name:string)
+    args |= %w(job_cache:text)
 
     super
   end


### PR DESCRIPTION
This is discussed in issue #11 
