### PR TITLE
Allow developer to control formatting of status label

### DIFF
--- a/lib/osc_machete_rails/helper.rb
+++ b/lib/osc_machete_rails/helper.rb
@@ -1,6 +1,6 @@
 module OscMacheteRails
   module Helper
-    def status_label(job)
+    def status_label(job, tag = :span)
       job ||= OpenStruct.new status: OSC::Machete::Status.not_submitted
       text = job.status.to_s
 
@@ -14,7 +14,7 @@ module OscMacheteRails
         label_class = 'label-primary'
       end
 
-      content_tag :span, class: %I(label #{label_class}) do
+      content_tag tag, class: %I(status-label label #{label_class}) do
         text
       end
     end


### PR DESCRIPTION
Allows the developer to specify the tag instead of assuming `<span>`:

```
<%= status_label workflow, :div %>
```

Also, we add an html class `status-label` to the element, so that developers can style the status labels to their heart's content.
