### PR TITLE
can accept rails 5 or higher

### DIFF
--- a/lib/osc_machete_rails/version.rb
+++ b/lib/osc_machete_rails/version.rb
@@ -1,3 +1,3 @@
 module OscMacheteRails
-  VERSION = "2.1.0"
+  VERSION = "2.1.1"
 end

--- a/osc_machete_rails.gemspec
+++ b/osc_machete_rails.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.files = Dir["{app,config,db,lib}/**/*", "LICENSE.txt", "Rakefile", "README.md", "CHANGELOG.md"]
   s.test_files = Dir["test/**/*"]
 
-  s.add_dependency "rails", "~> 5.0", ">= 5.0.0"
+  s.add_dependency "rails", ">= 5.0.0"
   s.add_dependency "osc-machete", "~> 2.0"
 
   s.add_development_dependency "sqlite3", "~> 1.4"


### PR DESCRIPTION
can accept rails 5 or higher. Right now `~> 5.x` locks us to versions no greater than 5.